### PR TITLE
add _drop key

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,5 @@
 # api
 
-note: supports all keys minetest does  
-
 ```lua
 controls.register_on_press(function(player, key)
     -- called on key down
@@ -22,4 +20,13 @@ controls.register_on_release(function(player, key, length)
     -- @key: key pressed
     -- @length: length of time key was held in seconds
 end)
+```
+
+# keys
+
+supports all the keys minetest does  
+
+special keys:
+```
+@_drop: called when a player drops an item
 ```

--- a/readme.md
+++ b/readme.md
@@ -28,5 +28,5 @@ supports all the keys minetest does
 
 special keys:
 ```
-@_drop: called when a player drops an item
+@_drop: called when a player drops an item (note: only supported in register_on_press api method)
 ```


### PR DESCRIPTION
adds a _drop key event. note, cant override minetest.item_drop since this will cause double events for existing since it is defined in minetest.registered_nodes.

redo of https://github.com/mt-mods/controls/pull/5